### PR TITLE
Add Dot Walk sample

### DIFF
--- a/apps/web/app/samples/dot-walk/page.tsx
+++ b/apps/web/app/samples/dot-walk/page.tsx
@@ -22,7 +22,7 @@ export default function DotWalk() {
     const dot = new Dot({
       position: new Vector2(400, 250),
       velocity: Vector2.zero(),
-      radius: 10,
+      radius: 20,
       color: "#000000",
       maxSpeed: 80,
       friction: 0.05,
@@ -36,15 +36,15 @@ export default function DotWalk() {
       position: dot.position.clone(),
       particleCount: 30,
       emissionRate: 5,
-      particleLifespan: 160,
+      particleLifespan: 60,
       direction: Vector2.fromAngle(Math.PI),
-      spread: Math.PI / 6,
+      spread: Math.PI / 3,
       velocityRange: {
         min: Vector2.fromAngle(0, 30),
         max: Vector2.fromAngle(0, 80),
       },
       colors: ["#333333"],
-      sizeRange: { min: 2, max: 8 },
+      sizeRange: { min: 2, max: 10 },
       friction: 0.02,
     });
     emitter.isActive = false;

--- a/apps/web/app/samples/dot-walk/page.tsx
+++ b/apps/web/app/samples/dot-walk/page.tsx
@@ -24,7 +24,7 @@ export default function DotWalk() {
       velocity: Vector2.zero(),
       radius: 10,
       color: "#000000",
-      maxSpeed: 50,
+      maxSpeed: 80,
       friction: 0.05,
     });
 
@@ -36,15 +36,15 @@ export default function DotWalk() {
       position: dot.position.clone(),
       particleCount: 30,
       emissionRate: 5,
-      particleLifespan: 60,
+      particleLifespan: 160,
       direction: Vector2.fromAngle(Math.PI),
       spread: Math.PI / 6,
       velocityRange: {
         min: Vector2.fromAngle(0, 30),
         max: Vector2.fromAngle(0, 80),
       },
-      colors: ["#cccccc", "#333333"],
-      sizeRange: { min: 2, max: 4 },
+      colors: ["#333333"],
+      sizeRange: { min: 2, max: 8 },
       friction: 0.02,
     });
     emitter.isActive = false;
@@ -98,8 +98,8 @@ export default function DotWalk() {
 
       dot.update();
       dot.bounceOffBounds(canvas.width, canvas.height, 0.9);
+      // 速度に応じてParticleの数を変更する
       const count = MotionUtil.map(dot.velocity.magnitude(),0,50,0,30)
-      console.log(count)
       emitter.setEmissionCount(count)
       emitter.setPosition(dot.position);
       emitter.setDirection(Vector2.fromAngle(orientation + Math.PI));

--- a/apps/web/app/samples/dot-walk/page.tsx
+++ b/apps/web/app/samples/dot-walk/page.tsx
@@ -98,8 +98,8 @@ export default function DotWalk() {
 
       dot.update();
       dot.bounceOffBounds(canvas.width, canvas.height, 0.9);
-      // 速度に応じてParticleの数を変更する
-      const count = MotionUtil.map(dot.velocity.magnitude(),0,50,0,30)
+      // 加速度に応じてParticleの数を変更する
+      const count = MotionUtil.map(dot.prevAccelleration.magnitude(),0,50,0,30)
       emitter.setEmissionCount(count)
       emitter.setPosition(dot.position);
       emitter.setDirection(Vector2.fromAngle(orientation + Math.PI));

--- a/apps/web/app/samples/dot-walk/page.tsx
+++ b/apps/web/app/samples/dot-walk/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Link from "next/link";
-import { CanvasUtil, Vector2, Dot, ParticleEmitter } from "@t2421/motion";
+import { CanvasUtil, Vector2, Dot, ParticleEmitter, MotionUtil } from "@t2421/motion";
 
 export default function DotWalk() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -23,8 +23,8 @@ export default function DotWalk() {
       position: new Vector2(400, 250),
       velocity: Vector2.zero(),
       radius: 10,
-      color: "#45b7d1",
-      maxSpeed: 300,
+      color: "#000000",
+      maxSpeed: 50,
       friction: 0.05,
     });
 
@@ -34,8 +34,8 @@ export default function DotWalk() {
 
     const emitter = new ParticleEmitter({
       position: dot.position.clone(),
-      particleCount: 1000,
-      emissionRate: 60,
+      particleCount: 30,
+      emissionRate: 5,
       particleLifespan: 60,
       direction: Vector2.fromAngle(Math.PI),
       spread: Math.PI / 6,
@@ -43,7 +43,7 @@ export default function DotWalk() {
         min: Vector2.fromAngle(0, 30),
         max: Vector2.fromAngle(0, 80),
       },
-      colors: ["#fbbf24", "#fde047"],
+      colors: ["#cccccc", "#333333"],
       sizeRange: { min: 2, max: 4 },
       friction: 0.02,
     });
@@ -98,7 +98,9 @@ export default function DotWalk() {
 
       dot.update();
       dot.bounceOffBounds(canvas.width, canvas.height, 0.9);
-
+      const count = MotionUtil.map(dot.velocity.magnitude(),0,50,0,30)
+      console.log(count)
+      emitter.setEmissionCount(count)
       emitter.setPosition(dot.position);
       emitter.setDirection(Vector2.fromAngle(orientation + Math.PI));
       emitter.update();

--- a/apps/web/app/samples/dot-walk/page.tsx
+++ b/apps/web/app/samples/dot-walk/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import Link from "next/link";
+import { CanvasUtil, Vector2, Dot, ParticleEmitter } from "@t2421/motion";
+
+export default function DotWalk() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    canvas.width = 800;
+    canvas.height = 500;
+
+    let animationId: number;
+
+    const dot = new Dot({
+      position: new Vector2(400, 250),
+      velocity: Vector2.zero(),
+      radius: 10,
+      color: "#45b7d1",
+      maxSpeed: 300,
+      friction: 0.05,
+    });
+
+    let orientation = 0; // radians
+    const rotationSpeed = Math.PI / 90; // per frame
+    const thrust = 100;
+
+    const emitter = new ParticleEmitter({
+      position: dot.position.clone(),
+      particleCount: 1000,
+      emissionRate: 60,
+      particleLifespan: 60,
+      direction: Vector2.fromAngle(Math.PI),
+      spread: Math.PI / 6,
+      velocityRange: {
+        min: Vector2.fromAngle(0, 30),
+        max: Vector2.fromAngle(0, 80),
+      },
+      colors: ["#fbbf24", "#fde047"],
+      sizeRange: { min: 2, max: 4 },
+      friction: 0.02,
+    });
+    emitter.isActive = false;
+
+    const keys: Record<string, boolean> = {};
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.code)
+      ) {
+        keys[e.code] = true;
+        e.preventDefault();
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (
+        ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.code)
+      ) {
+        keys[e.code] = false;
+        e.preventDefault();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    function animate() {
+      if (!canvas || !ctx) return;
+
+      ctx.fillStyle = "#f8f9fa";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      CanvasUtil.drawGrid(canvas, { interval: 20, color: "#e9ecef" });
+
+      if (keys["ArrowLeft"]) orientation -= rotationSpeed;
+      if (keys["ArrowRight"]) orientation += rotationSpeed;
+
+      if (keys["ArrowUp"]) {
+        const force = Vector2.fromAngle(orientation, thrust);
+        dot.applyForce(force);
+        emitter.isActive = true;
+      } else {
+        emitter.isActive = false;
+      }
+
+      if (keys["ArrowDown"]) {
+        const force = Vector2.fromAngle(orientation + Math.PI, thrust);
+        dot.applyForce(force);
+      }
+
+      dot.update();
+      dot.bounceOffBounds(canvas.width, canvas.height, 0.9);
+
+      emitter.setPosition(dot.position);
+      emitter.setDirection(Vector2.fromAngle(orientation + Math.PI));
+      emitter.update();
+      emitter.draw(ctx);
+
+      dot.draw(ctx);
+      CanvasUtil.drawVector(
+        ctx,
+        dot.position,
+        Vector2.fromAngle(orientation, 20),
+        {
+          color: "#e91e63",
+          lineWidth: 2,
+          label: "",
+          arrowHeadLength: 6,
+        },
+      );
+
+      animationId = requestAnimationFrame(animate);
+    }
+
+    animate();
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      if (animationId) cancelAnimationFrame(animationId);
+    };
+  }, []);
+
+  return (
+    <div style={{ padding: "2rem", maxWidth: "1000px", margin: "0 auto" }}>
+      <header style={{ marginBottom: "2rem" }}>
+        <Link href="/" style={{ color: "#667eea", textDecoration: "none" }}>
+          ← Back to Gallery
+        </Link>
+        <h1 style={{ marginTop: "1rem", marginBottom: "0.5rem" }}>Dot Walk</h1>
+        <p style={{ color: "#666" }}>
+          Move the dot using the arrow keys. Particles emit from the opposite
+          direction when thrusting forward.
+        </p>
+      </header>
+
+      <div
+        style={{
+          border: "1px solid #ddd",
+          borderRadius: "8px",
+          overflow: "hidden",
+          marginBottom: "2rem",
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          style={{ display: "block", width: "100%", height: "auto" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/samples.ts
+++ b/apps/web/lib/samples.ts
@@ -4,128 +4,139 @@ export interface Sample {
   description: string;
   thumbnail: string;
   path: string;
-  category: 'vector' | 'shapes' | 'bezier' | 'utils' | 'physics';
+  category: "vector" | "shapes" | "bezier" | "utils" | "physics";
 }
 
 export const samples: Sample[] = [
   {
-    id: 'vector-basics',
-    title: 'Vector Basics',
-    description: 'Basic vector operations: add, subtract, normalize',
-    thumbnail: '/thumbnails/vector-basics.svg',
-    path: '/samples/vector-basics',
-    category: 'vector'
+    id: "vector-basics",
+    title: "Vector Basics",
+    description: "Basic vector operations: add, subtract, normalize",
+    thumbnail: "/thumbnails/vector-basics.svg",
+    path: "/samples/vector-basics",
+    category: "vector",
   },
   {
-    id: 'dot-basic',
-    title: 'Dot Physics',
-    description: 'Interactive dots with position, velocity, and acceleration',
-    thumbnail: '/thumbnails/dot-basic.svg',
-    path: '/samples/dot-basic',
-    category: 'physics'
+    id: "dot-basic",
+    title: "Dot Physics",
+    description: "Interactive dots with position, velocity, and acceleration",
+    thumbnail: "/thumbnails/dot-basic.svg",
+    path: "/samples/dot-basic",
+    category: "physics",
   },
   {
-    id: 'dot-repulsive',
-    title: 'Dot Repulsive Force',
-    description: 'Dots flee from the mouse cursor using repulsive forces',
-    thumbnail: '/thumbnails/dot-repulsive.svg',
-    path: '/samples/dot-repulsive',
-    category: 'physics'
+    id: "dot-repulsive",
+    title: "Dot Repulsive Force",
+    description: "Dots flee from the mouse cursor using repulsive forces",
+    thumbnail: "/thumbnails/dot-repulsive.svg",
+    path: "/samples/dot-repulsive",
+    category: "physics",
   },
   {
-    id: 'dot-wind',
-    title: 'Dot Wind & Constraints',
-    description: 'Dots affected by wind forces with distance constraints from mouse cursor',
-    thumbnail: '/thumbnails/dot-wind.svg',
-    path: '/samples/dot-wind',
-    category: 'physics'
+    id: "dot-wind",
+    title: "Dot Wind & Constraints",
+    description:
+      "Dots affected by wind forces with distance constraints from mouse cursor",
+    thumbnail: "/thumbnails/dot-wind.svg",
+    path: "/samples/dot-wind",
+    category: "physics",
   },
   {
-    id: 'dot-multi-connect',
-    title: 'Multi-Connected Dot',
-    description: 'Single dot connected to multiple anchor points with springs',
-    thumbnail: '/thumbnails/dot-multi-connect.svg',
-    path: '/samples/dot-multi-connect',
-    category: 'physics'
+    id: "dot-walk",
+    title: "Dot Walk",
+    description:
+      "Control a dot with arrow keys and emit particles when thrusting",
+    thumbnail: "/thumbnails/dot-walk.svg",
+    path: "/samples/dot-walk",
+    category: "physics",
   },
   {
-    id: 'particle-emitter',
-    title: 'Particle Emitter System',
-    description: 'Advanced particle system with multiple shapes and emission patterns',
-    thumbnail: '/thumbnails/particle-emitter.svg',
-    path: '/samples/particle-emitter',
-    category: 'physics'
+    id: "dot-multi-connect",
+    title: "Multi-Connected Dot",
+    description: "Single dot connected to multiple anchor points with springs",
+    thumbnail: "/thumbnails/dot-multi-connect.svg",
+    path: "/samples/dot-multi-connect",
+    category: "physics",
   },
   {
-    id: 'animated-shapes',
-    title: 'Animated Shapes',
-    description: 'Circle, Rectangle, Triangle animations',
-    thumbnail: '/thumbnails/animated-shapes.svg',
-    path: '/samples/animated-shapes',
-    category: 'shapes'
+    id: "particle-emitter",
+    title: "Particle Emitter System",
+    description:
+      "Advanced particle system with multiple shapes and emission patterns",
+    thumbnail: "/thumbnails/particle-emitter.svg",
+    path: "/samples/particle-emitter",
+    category: "physics",
   },
   {
-    id: 'bezier-curves',
-    title: 'Bezier Curves',
-    description: 'Interactive bezier curve visualization',
-    thumbnail: '/thumbnails/bezier-curves.svg',
-    path: '/samples/bezier-curves',
-    category: 'bezier'
+    id: "animated-shapes",
+    title: "Animated Shapes",
+    description: "Circle, Rectangle, Triangle animations",
+    thumbnail: "/thumbnails/animated-shapes.svg",
+    path: "/samples/animated-shapes",
+    category: "shapes",
   },
   {
-    id: 'easing-functions',
-    title: 'Easing Functions',
-    description: 'Compare different easing functions',
-    thumbnail: '/thumbnails/easing-functions.svg',
-    path: '/samples/easing-functions',
-    category: 'bezier'
+    id: "bezier-curves",
+    title: "Bezier Curves",
+    description: "Interactive bezier curve visualization",
+    thumbnail: "/thumbnails/bezier-curves.svg",
+    path: "/samples/bezier-curves",
+    category: "bezier",
   },
   {
-    id: 'motion-utils',
-    title: 'Motion Utils',
-    description: 'Utility functions: lerp, clamp, map',
-    thumbnail: '/thumbnails/motion-utils.svg',
-    path: '/samples/motion-utils',
-    category: 'utils'
+    id: "easing-functions",
+    title: "Easing Functions",
+    description: "Compare different easing functions",
+    thumbnail: "/thumbnails/easing-functions.svg",
+    path: "/samples/easing-functions",
+    category: "bezier",
   },
   {
-    id: 'vector-dot-product',
-    title: 'Vector Dot Product',
-    description: 'Interactive dot product visualization and projection',
-    thumbnail: '/thumbnails/vector-dot-product.svg',
-    path: '/samples/vector-dot-product',
-    category: 'vector'
+    id: "motion-utils",
+    title: "Motion Utils",
+    description: "Utility functions: lerp, clamp, map",
+    thumbnail: "/thumbnails/motion-utils.svg",
+    path: "/samples/motion-utils",
+    category: "utils",
   },
   {
-    id: 'vector-cross-product',
-    title: 'Vector Cross Product',
-    description: 'Cross product, area calculation, and rotation direction',
-    thumbnail: '/thumbnails/vector-cross-product.svg',
-    path: '/samples/vector-cross-product',
-    category: 'vector'
+    id: "vector-dot-product",
+    title: "Vector Dot Product",
+    description: "Interactive dot product visualization and projection",
+    thumbnail: "/thumbnails/vector-dot-product.svg",
+    path: "/samples/vector-dot-product",
+    category: "vector",
   },
   {
-    id: 'vector-lerp',
-    title: 'Vector Lerp',
-    description: 'Linear interpolation between vectors for smooth animations',
-    thumbnail: '/thumbnails/vector-lerp.svg',
-    path: '/samples/vector-lerp',
-    category: 'vector'
+    id: "vector-cross-product",
+    title: "Vector Cross Product",
+    description: "Cross product, area calculation, and rotation direction",
+    thumbnail: "/thumbnails/vector-cross-product.svg",
+    path: "/samples/vector-cross-product",
+    category: "vector",
   },
   {
-    id: 'vector-reflect',
-    title: 'Vector Reflection',
-    description: 'Vector reflection across surfaces and collision response',
-    thumbnail: '/thumbnails/vector-reflect.svg',
-    path: '/samples/vector-reflect',
-    category: 'vector'
-  }
+    id: "vector-lerp",
+    title: "Vector Lerp",
+    description: "Linear interpolation between vectors for smooth animations",
+    thumbnail: "/thumbnails/vector-lerp.svg",
+    path: "/samples/vector-lerp",
+    category: "vector",
+  },
+  {
+    id: "vector-reflect",
+    title: "Vector Reflection",
+    description: "Vector reflection across surfaces and collision response",
+    thumbnail: "/thumbnails/vector-reflect.svg",
+    path: "/samples/vector-reflect",
+    category: "vector",
+  },
 ];
 
 export const categories = {
-  vector: 'Vector Calculations',
-  physics: 'Physics & Particles',
-  shapes: 'Geometric Shapes',
-  bezier: 'Bezier & Easing',
-  utils: 'Utility Functions'
+  vector: "Vector Calculations",
+  physics: "Physics & Particles",
+  shapes: "Geometric Shapes",
+  bezier: "Bezier & Easing",
+  utils: "Utility Functions",
 } as const;

--- a/apps/web/public/thumbnails/dot-walk.svg
+++ b/apps/web/public/thumbnails/dot-walk.svg
@@ -1,0 +1,77 @@
+<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="300" height="200" fill="#f8f9fa"/>
+  
+  <!-- Grid -->
+  <defs>
+    <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e9ecef" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="300" height="200" fill="url(#grid)"/>
+  
+  <!-- Vector arrow markers -->
+  <defs>
+    <marker id="velocity-arrow" markerWidth="6" markerHeight="6" 
+     refX="6" refY="3" orient="auto">
+      <polygon points="0 0, 6 3, 0 6" fill="#4ecdc4"/>
+    </marker>
+    <marker id="acceleration-arrow" markerWidth="6" markerHeight="6" 
+     refX="6" refY="3" orient="auto">
+      <polygon points="0 0, 6 3, 0 6" fill="#ff6b6b"/>
+    </marker>
+  </defs>
+  
+  <!-- Bouncing ball (red) -->
+  <circle cx="60" cy="80" r="12" fill="#ff6b6b"/>
+  <line x1="60" y1="80" x2="100" y2="60" stroke="#4ecdc4" stroke-width="2" marker-end="url(#velocity-arrow)"/>
+  <line x1="60" y1="80" x2="50" y2="110" stroke="#ff6b6b" stroke-width="2" marker-end="url(#acceleration-arrow)"/>
+  
+  <!-- Floating particle (cyan) -->
+  <circle cx="150" cy="50" r="8" fill="#4ecdc4"/>
+  <line x1="150" y1="50" x2="130" y2="70" stroke="#4ecdc4" stroke-width="2" marker-end="url(#velocity-arrow)"/>
+  
+  <!-- Heavy dot (purple) -->
+  <circle cx="220" cy="120" r="15" fill="#9c27b0"/>
+  <line x1="220" y1="120" x2="190" y2="100" stroke="#4ecdc4" stroke-width="2" marker-end="url(#velocity-arrow)"/>
+  <line x1="220" y1="120" x2="240" y2="140" stroke="#ff6b6b" stroke-width="2" marker-end="url(#acceleration-arrow)"/>
+  
+  <!-- Light, fast dot (orange) -->
+  <circle cx="240" cy="60" r="6" fill="#ffa726"/>
+  <line x1="240" y1="60" x2="200" y2="80" stroke="#4ecdc4" stroke-width="2" marker-end="url(#velocity-arrow)"/>
+  
+  <!-- Mouse-controlled dot (blue) -->
+  <circle cx="120" cy="140" r="10" fill="#45b7d1"/>
+  <line x1="120" y1="140" x2="140" y2="120" stroke="#4ecdc4" stroke-width="2" marker-end="url(#velocity-arrow)"/>
+  
+  <!-- Mouse cursor indicator -->
+  <circle cx="140" cy="120" r="3" fill="#333"/>
+  <line x1="120" y1="140" x2="140" y2="120" stroke="#45b7d1" stroke-width="1" stroke-dasharray="3,3"/>
+  
+  <!-- Motion trails -->
+  <circle cx="45" cy="85" r="3" fill="#ff6b6b" opacity="0.3"/>
+  <circle cx="30" cy="90" r="2" fill="#ff6b6b" opacity="0.2"/>
+  <circle cx="15" cy="95" r="1" fill="#ff6b6b" opacity="0.1"/>
+  
+  <circle cx="165" cy="45" r="2" fill="#4ecdc4" opacity="0.3"/>
+  <circle cx="180" cy="40" r="1" fill="#4ecdc4" opacity="0.2"/>
+  
+  <!-- Legend -->
+  <g transform="translate(20, 160)">
+    <circle cx="5" cy="5" r="3" fill="#4ecdc4"/>
+    <text x="12" y="9" font-family="Arial" font-size="10" fill="#666">Velocity</text>
+    
+    <circle cx="60" cy="5" r="3" fill="#ff6b6b"/>
+    <text x="67" y="9" font-family="Arial" font-size="10" fill="#666">Acceleration</text>
+    
+    <circle cx="130" cy="5" r="3" fill="#333"/>
+    <text x="137" y="9" font-family="Arial" font-size="10" fill="#666">Mouse</text>
+  </g>
+  
+  <!-- Boundary walls -->
+  <rect x="0" y="0" width="300" height="200" fill="none" stroke="#999" stroke-width="2"/>
+  
+  <!-- Title -->
+  <text x="150" y="25" text-anchor="middle" font-family="Arial" font-size="16" font-weight="bold" fill="#333">Dot Walk</text>
+  <text x="150" y="40" text-anchor="middle" font-family="Arial" font-size="12" fill="#666">Arrow key movement with particles</text>
+</svg>

--- a/packages/motion/src/mover.ts
+++ b/packages/motion/src/mover.ts
@@ -9,7 +9,7 @@ export class Mover {
   public position: Vector2;
   public velocity: Vector2;
   public acceleration: Vector2;
-  private prevAccelleration: Vector2; // for debug
+  public prevAccelleration: Vector2; // for debug
   public mass: number;
   public maxSpeed: number;
   public friction: number;

--- a/packages/motion/src/particle-emitter.ts
+++ b/packages/motion/src/particle-emitter.ts
@@ -305,11 +305,6 @@ export class ParticleEmitter {
       this.particlesEmitted = 0;
       this.isActive = true;
       
-      // Clear existing particles if we're reducing the count
-      if (count < this.particles.length) {
-        this.particles = this.particles.slice(0, count);
-      }
-      
       // For burst pattern, immediately emit all particles
       if (this.config.pattern === EmissionPattern.BURST) {
         this.emitBurst();

--- a/packages/motion/src/particle-emitter.ts
+++ b/packages/motion/src/particle-emitter.ts
@@ -123,10 +123,14 @@ export class ParticleEmitter {
       
       particle.update(deltaTime);
       
-      // Reuse dead particles instead of removing them
-      if (particle.isDead) {
-        this.recycleParticle(particle);
+      if(particle.isDead){
+        if(this.config.particleCount > this.particles.length){
+          this.recycleParticle(particle);
+        }else{
+          this.particles.splice(i, 1);
+        }
       }
+     
     }
   }
 
@@ -289,7 +293,32 @@ export class ParticleEmitter {
     this.position = position.clone();
     this.config.position = position.clone();
   }
-
+  /**
+   * Set emission count and regenerate particles if needed
+   */
+  setEmissionCount(count: number): void {
+    const oldCount = this.config.particleCount;
+    this.config.particleCount = count;
+    
+    // Reset emission state when count changes
+    if (oldCount !== count) {
+      this.particlesEmitted = 0;
+      this.isActive = true;
+      
+      // Clear existing particles if we're reducing the count
+      if (count < this.particles.length) {
+        this.particles = this.particles.slice(0, count);
+      }
+      
+      // For burst pattern, immediately emit all particles
+      if (this.config.pattern === EmissionPattern.BURST) {
+        this.emitBurst();
+      }
+    }
+  }
+  setEmissionRate(rate: number): void {
+    this.config.emissionRate = rate
+  }
   /**
    * Set velocity range for particles
    */


### PR DESCRIPTION
## Summary
- add a new `dot-walk` sample with keyboard controls and particle effects
- register the sample in the gallery
- provide a thumbnail for the new sample

## Testing
- `pnpm install`
- `pnpm build`
- `pnpm lint` *(fails: SyntaxError in eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68789c4ee64c8328b45d3173c7636632